### PR TITLE
Add builder stage for pe-server

### DIFF
--- a/pe-server/Dockerfile
+++ b/pe-server/Dockerfile
@@ -1,3 +1,11 @@
+FROM maven as builder
+
+WORKDIR /app
+
+COPY ./ /app
+
+RUN mvn install
+
 # base image
 FROM openjdk:13-jdk-alpine
 
@@ -5,7 +13,7 @@ FROM openjdk:13-jdk-alpine
 WORKDIR /app
 
 # add app
-COPY ./services/web/target/web-*.jar /app/app.jar
+COPY --from=builder /app/services/web/target/web-*.jar /app/app.jar
 
 VOLUME /var/lib/processexplorer/
 


### PR DESCRIPTION
Adds Maven as a builder stage to pe-server's Dockerfile, so that no manual building is necessary.

Also the project can quickly be spun up by just running `docker-compose up` now.